### PR TITLE
fix missing '=' in the OSX patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ here's the `tl;dr` on enabling _italics_ in OSX.
 
 ```bash
 infocmp xterm-256color > /tmp/xterm-256color.terminfo
-printf '\tsitm\\E[3m, ritm=\\E[23m,\n' >> /tmp/xterm-256color.terminfo
+printf '\tsitm=\\E[3m, ritm=\\E[23m,\n' >> /tmp/xterm-256color.terminfo
 tic /tmp/xterm-256color.terminfo
 ```
 


### PR DESCRIPTION
Thanks! :)