### PR TITLE
fix deprecated CommonMark to commonmark

### DIFF
--- a/consolemd/renderer.py
+++ b/consolemd/renderer.py
@@ -2,7 +2,7 @@
 
 import sys
 
-import CommonMark
+import commonmark
 import pygments
 import pygments.lexers
 import pygments.styles
@@ -32,7 +32,7 @@ class Renderer(object):
 
     def __init__(self, parser=None, style_name=None):
         if parser is None:
-            parser = CommonMark.Parser()
+            parser = commonmark.Parser()
 
         if style_name is None:
             style_name = 'native'


### PR DESCRIPTION
https://github.com/rolandshoemaker/CommonMark-py is deprecated and replace to https://github.com/rtfd/CommonMark-py

ref: https://pypi.org/project/CommonMark

The latest CommonMark-py module name is `commonmark` instead of `CommonMark`.

In version 0.8.1, `CommonMark` symlink is removed.
https://github.com/rtfd/CommonMark-py/pull/135
https://github.com/rtfd/CommonMark-py/commit/1ba9ab47a7c0df18c9bf43fcf876d20c9472d87a

Several test cases have failed due to this change.

I fixed module name.

## test case result (after fix)
```
(consolemd) % python3 setup.py test
running pytest
Searching for pytest-console-scripts
Best match: pytest-console-scripts 0.1.5
Processing pytest_console_scripts-0.1.5-py3.6.egg

Using /Users/yukihaneda/src/github.com/ap8322/consolemd/.eggs/pytest_console_scripts-0.1.5-py3.6.egg
Searching for pytest
Best match: pytest 3.8.0
Processing pytest-3.8.0-py3.6.egg

Using /Users/yukihaneda/src/github.com/ap8322/consolemd/.eggs/pytest-3.8.0-py3.6.egg
Searching for mock>=2.0.0
Best match: mock 2.0.0
Processing mock-2.0.0-py3.6.egg

Using /Users/yukihaneda/src/github.com/ap8322/consolemd/.eggs/mock-2.0.0-py3.6.egg
Searching for six>=1.10.0
Best match: six 1.11.0
Processing six-1.11.0-py3.6.egg

Using /Users/yukihaneda/src/github.com/ap8322/consolemd/.eggs/six-1.11.0-py3.6.egg
Searching for py>=1.5.0
Best match: py 1.6.0
Processing py-1.6.0-py3.6.egg

Using /Users/yukihaneda/src/github.com/ap8322/consolemd/.eggs/py-1.6.0-py3.6.egg
Searching for pluggy>=0.7
Best match: pluggy 0.7.1
Processing pluggy-0.7.1-py3.6.egg

Using /Users/yukihaneda/src/github.com/ap8322/consolemd/.eggs/pluggy-0.7.1-py3.6.egg
Searching for more-itertools>=4.0.0
Best match: more-itertools 4.3.0
Processing more_itertools-4.3.0-py3.6.egg

Using /Users/yukihaneda/src/github.com/ap8322/consolemd/.eggs/more_itertools-4.3.0-py3.6.egg
Searching for attrs>=17.4.0
Best match: attrs 18.2.0
Processing attrs-18.2.0-py3.6.egg

Using /Users/yukihaneda/src/github.com/ap8322/consolemd/.eggs/attrs-18.2.0-py3.6.egg
Searching for atomicwrites>=1.0
Best match: atomicwrites 1.2.1
Processing atomicwrites-1.2.1-py3.6.egg

Using /Users/yukihaneda/src/github.com/ap8322/consolemd/.eggs/atomicwrites-1.2.1-py3.6.egg
Searching for pbr>=0.11
Best match: pbr 4.2.0
Processing pbr-4.2.0-py3.6.egg

Using /Users/yukihaneda/src/github.com/ap8322/consolemd/.eggs/pbr-4.2.0-py3.6.egg
running egg_info
writing consolemd.egg-info/PKG-INFO
writing dependency_links to consolemd.egg-info/dependency_links.txt
writing entry points to consolemd.egg-info/entry_points.txt
writing requirements to consolemd.egg-info/requires.txt
writing top-level names to consolemd.egg-info/top_level.txt
reading manifest file 'consolemd.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'consolemd.egg-info/SOURCES.txt'
running build_ext
==================================================================================== test session starts ====================================================================================
platform darwin -- Python 3.6.5, pytest-3.8.0, py-1.6.0, pluggy-0.7.1
rootdir: /Users/yukihaneda/src/github.com/ap8322/consolemd, inifile: pytest.ini
plugins: console-scripts-0.1.5
collected 4 items

tests/test_cmdline.py ....                                                                                                                                                            [100%]

================================================================================= 4 passed in 7.52 seconds ==================================================================================
```